### PR TITLE
fix: send decimal channel mask instead of binary string

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -725,7 +725,7 @@ internal class Program
                     var adcCount = streamingDevice.Metadata.Capabilities.AnalogInputChannels;
                     if (adcCount > 0)
                     {
-                        channelMask = new string('1', adcCount);
+                        channelMask = ((1u << adcCount) - 1).ToString();
                     }
                 }
 
@@ -1289,15 +1289,7 @@ internal class Program
 
     private static bool IsValidChannelMask(string channelMask)
     {
-        foreach (var value in channelMask)
-        {
-            if (value != '0' && value != '1')
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return uint.TryParse(channelMask, out _);
     }
 
     private static void PrintHelp()
@@ -1322,7 +1314,7 @@ internal class Program
         Console.WriteLine("Streaming Options:");
         Console.WriteLine($"  --rate <hz>              Streaming rate in Hz (default: {DefaultRate}).");
         Console.WriteLine($"  --duration <seconds>     Duration to stream (default: {DefaultDurationSeconds}).");
-        Console.WriteLine("  --channels <mask>        Enable ADC channels with a 0/1 mask.");
+        Console.WriteLine("  --channels <mask>        Enable ADC channels with a decimal bitmask (e.g. 7 = ch 0,1,2).");
         Console.WriteLine("  --limit <count>          Stop after N stream messages.");
         Console.WriteLine("  --min-samples <count>    Require at least N stream messages (exit code 2 on failure).");
         Console.WriteLine();


### PR DESCRIPTION
## Summary

- `IsValidChannelMask()` only accepted binary strings (0s and 1s) and the `--channels` help text said "0/1 mask". The firmware's `SCPI_ParamInt32` parses `ENAble:VOLTage:DC` as a **decimal integer**, so `--channels 111` (intended as binary for ch 0,1,2) was parsed as decimal 111 = wrong channels.
- Auto-generated all-channel mask used `new string('1', adcCount)` which for 8 channels produced `"11111111"` — firmware parses as decimal 11,111,111 instead of the correct `255`.
- `IsValidChannelMask` now validates decimal integers via `uint.TryParse`.
- Auto-mask now computes `(1 << count) - 1` (e.g. 255 for 8 channels).
- Help text updated to show decimal bitmask format.

Related: daqifi/daqifi-desktop#439, daqifi/daqifi-core#160

## Test plan

- [x] Build succeeds with local core
- [x] `--channels 7` correctly logged only channels 0,1,2 on real hardware (Nq1 @ `/dev/cu.usbmodem101`) — downloaded file showed 3 analog values per sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)