### PR TITLE
feat: add --sd-export-csv command for SD card log files

### DIFF
--- a/Daqifi.Core.Cli.csproj
+++ b/Daqifi.Core.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Daqifi.Core.Cli.csproj
+++ b/Daqifi.Core.Cli.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DaqifiCoreProjectPath)' == ''">
-    <PackageReference Include="Daqifi.Core" Version="0.19.4" />
+    <PackageReference Include="Daqifi.Core" Version="0.20.0" />
   </ItemGroup>
 
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -129,22 +129,6 @@ internal class Program
             return await RunLanChipInfoAsync(options);
         }
 
-        if (options.MimicDesktop)
-        {
-            if (string.IsNullOrWhiteSpace(options.SerialPort))
-            {
-                Console.Error.WriteLine("--mimic-desktop requires --serial.");
-                return 1;
-            }
-            return await DesktopFlowTest.RunAsync(
-                options.SerialPort!,
-                options.MimicDesktopChannels,
-                options.DurationSeconds,
-                options.MimicDesktopFrequency,
-                options.MimicDesktopSendDio,
-                options.MimicDesktopDelayMs);
-        }
-
         return await RunStreamingSessionAsync(options);
     }
 
@@ -1019,7 +1003,7 @@ internal class Program
                 rowsWritten = count;
                 if (stopwatch.Elapsed - lastReport > TimeSpan.FromMilliseconds(250))
                 {
-                    Console.Write($"\r  {count} samples written ({count / Math.Max(1, stopwatch.Elapsed.TotalSeconds):N0} samples/s)");
+                    Console.Write($"\r  {count} rows written ({count / Math.Max(1, stopwatch.Elapsed.TotalSeconds):N0} rows/s)");
                     lastReport = stopwatch.Elapsed;
                 }
             });
@@ -1032,11 +1016,11 @@ internal class Program
 
         var fileInfo = new FileInfo(outputPath);
         var seconds = stopwatch.Elapsed.TotalSeconds;
-        var samplesPerSec = seconds > 0 ? rowsWritten / seconds : 0;
+        var rowsPerSec = seconds > 0 ? rowsWritten / seconds : 0;
         var mbPerSec = seconds > 0 ? fileInfo.Length / seconds / (1024.0 * 1024.0) : 0;
 
-        Console.WriteLine($"Wrote {rowsWritten:N0} samples ({fileInfo.Length:N0} bytes) in {seconds:F2}s");
-        Console.WriteLine($"  Throughput: {samplesPerSec:N0} samples/s, {mbPerSec:F2} MB/s");
+        Console.WriteLine($"Wrote {rowsWritten:N0} rows ({fileInfo.Length:N0} bytes) in {seconds:F2}s");
+        Console.WriteLine($"  Throughput: {rowsPerSec:N0} rows/s, {mbPerSec:F2} MB/s");
         return 0;
     }
 
@@ -1518,11 +1502,6 @@ internal class Program
         public string? FirmwareHexPath { get; private set; }
         public string? FirmwareUpdateLatestDirectory { get; private set; }
         public bool LanChipInfo { get; private set; }
-        public bool MimicDesktop { get; private set; }
-        public int MimicDesktopChannels { get; private set; } = 16;
-        public int MimicDesktopFrequency { get; private set; } = 100;
-        public bool MimicDesktopSendDio { get; private set; }
-        public int MimicDesktopDelayMs { get; private set; }
         public List<string> Errors { get; } = new();
 
         public static CliOptions Parse(string[] args)
@@ -1641,21 +1620,6 @@ internal class Program
                     case "--lan-chip-info":
                         options.LanChipInfo = true;
                         break;
-                    case "--mimic-desktop":
-                        options.MimicDesktop = true;
-                        break;
-                    case "--mimic-desktop-channels":
-                        options.MimicDesktopChannels = GetIntValue(args, ref i, arg, options.Errors, 16);
-                        break;
-                    case "--mimic-desktop-freq":
-                        options.MimicDesktopFrequency = GetIntValue(args, ref i, arg, options.Errors, 100);
-                        break;
-                    case "--mimic-desktop-send-dio":
-                        options.MimicDesktopSendDio = true;
-                        break;
-                    case "--mimic-desktop-delay-ms":
-                        options.MimicDesktopDelayMs = GetIntValue(args, ref i, arg, options.Errors, 0);
-                        break;
                     case "-h":
                     case "--help":
                         options.ShowHelp = true;
@@ -1696,6 +1660,12 @@ internal class Program
                 string.IsNullOrWhiteSpace(options.FirmwareDownloadTagDirectory))
             {
                 options.Errors.Add("Missing destination directory for --fw-download-tag.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.SdExportCsvPath) &&
+                string.IsNullOrWhiteSpace(options.SdParsePath))
+            {
+                options.Errors.Add("--sd-export-csv requires --sd-parse <path>.");
             }
 
             return options;

--- a/Program.cs
+++ b/Program.cs
@@ -9,6 +9,7 @@ using Daqifi.Core.Device.Discovery;
 using Daqifi.Core.Device.Protocol;
 using Daqifi.Core.Device.SdCard;
 using Daqifi.Core.Firmware;
+using Daqifi.Core.Logging.Export;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -126,6 +127,22 @@ internal class Program
         if (options.LanChipInfo)
         {
             return await RunLanChipInfoAsync(options);
+        }
+
+        if (options.MimicDesktop)
+        {
+            if (string.IsNullOrWhiteSpace(options.SerialPort))
+            {
+                Console.Error.WriteLine("--mimic-desktop requires --serial.");
+                return 1;
+            }
+            return await DesktopFlowTest.RunAsync(
+                options.SerialPort!,
+                options.MimicDesktopChannels,
+                options.DurationSeconds,
+                options.MimicDesktopFrequency,
+                options.MimicDesktopSendDio,
+                options.MimicDesktopDelayMs);
         }
 
         return await RunStreamingSessionAsync(options);
@@ -923,6 +940,11 @@ internal class Program
                 if (cfg.DeviceSerialNumber != null) Console.WriteLine($"  Serial number:    {cfg.DeviceSerialNumber}");
             }
 
+            if (!string.IsNullOrWhiteSpace(options.SdExportCsvPath))
+            {
+                return await ExportSdSessionToCsvAsync(session, options.SdExportCsvPath!);
+            }
+
             var sampleCount = 0;
             using var outputWriter = CreateOutputWriter(options);
 
@@ -948,6 +970,91 @@ internal class Program
         {
             Console.Error.WriteLine($"Error parsing file: {FormatException(ex)}");
             return 1;
+        }
+    }
+
+    private static async Task<int> ExportSdSessionToCsvAsync(SdCardLogSession session, string outputPath)
+    {
+        // Determine analog port count: prefer the file's status message; fall back to peeking
+        // the first sample (which carries the actual emitted analog values).
+        IAsyncEnumerable<SdCardLogEntry> samplesForExport;
+        int analogCount;
+
+        if (session.DeviceConfig is not null)
+        {
+            analogCount = session.DeviceConfig.AnalogPortCount;
+            samplesForExport = session.Samples;
+        }
+        else
+        {
+            var enumerator = session.Samples.GetAsyncEnumerator();
+            if (!await enumerator.MoveNextAsync())
+            {
+                Console.Error.WriteLine("Cannot export to CSV: file is empty.");
+                await enumerator.DisposeAsync();
+                return 1;
+            }
+
+            var first = enumerator.Current;
+            analogCount = first.AnalogValues.Count;
+            samplesForExport = PrependAndStreamAsync(first, enumerator);
+        }
+
+        var sampleSource = new SdCardSampleSource(
+            new SdCardLogSession(session.FileName, session.FileCreatedDate, session.DeviceConfig, samplesForExport),
+            analogCount);
+        var exporter = new CsvExporter();
+        var exportOptions = new CsvExportOptions { UseRelativeTime = false };
+
+        Console.WriteLine($"Exporting CSV to: {outputPath}");
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        long rowsWritten = 0;
+        var lastReport = stopwatch.Elapsed;
+
+        await using (var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+        await using (var writer = new StreamWriter(fileStream))
+        {
+            var countingSource = new CountingSampleSource(sampleSource, count =>
+            {
+                rowsWritten = count;
+                if (stopwatch.Elapsed - lastReport > TimeSpan.FromMilliseconds(250))
+                {
+                    Console.Write($"\r  {count} samples written ({count / Math.Max(1, stopwatch.Elapsed.TotalSeconds):N0} samples/s)");
+                    lastReport = stopwatch.Elapsed;
+                }
+            });
+
+            await exporter.ExportAsync(countingSource, writer, exportOptions);
+        }
+
+        stopwatch.Stop();
+        Console.WriteLine();
+
+        var fileInfo = new FileInfo(outputPath);
+        var seconds = stopwatch.Elapsed.TotalSeconds;
+        var samplesPerSec = seconds > 0 ? rowsWritten / seconds : 0;
+        var mbPerSec = seconds > 0 ? fileInfo.Length / seconds / (1024.0 * 1024.0) : 0;
+
+        Console.WriteLine($"Wrote {rowsWritten:N0} samples ({fileInfo.Length:N0} bytes) in {seconds:F2}s");
+        Console.WriteLine($"  Throughput: {samplesPerSec:N0} samples/s, {mbPerSec:F2} MB/s");
+        return 0;
+    }
+
+    private static async IAsyncEnumerable<SdCardLogEntry> PrependAndStreamAsync(
+        SdCardLogEntry first,
+        IAsyncEnumerator<SdCardLogEntry> rest)
+    {
+        try
+        {
+            yield return first;
+            while (await rest.MoveNextAsync())
+            {
+                yield return rest.Current;
+            }
+        }
+        finally
+        {
+            await rest.DisposeAsync();
         }
     }
 
@@ -1332,6 +1439,7 @@ internal class Program
         Console.WriteLine("  --sd-download <filename> Download a file from the SD card (USB/serial only).");
         Console.WriteLine("  --sd-format              Format the SD card (erases all data).");
         Console.WriteLine("  --sd-parse <path>        Parse a .bin log file from the SD card.");
+        Console.WriteLine("  --sd-export-csv <path>   With --sd-parse, write samples as CSV to <path> using Daqifi.Core's CsvExporter.");
         Console.WriteLine("  --sd-capture-parse <p>   Capture live stream to file, then parse it.");
         Console.WriteLine();
         Console.WriteLine("Firmware Download Options:");
@@ -1402,6 +1510,7 @@ internal class Program
         public string? SdDownloadFileName { get; private set; }
         public bool SdFormat { get; private set; }
         public string? SdParsePath { get; set; }
+        public string? SdExportCsvPath { get; private set; }
         public string? CaptureAndParsePath { get; private set; }
         public string? FirmwareDownloadLatestDirectory { get; private set; }
         public string? FirmwareDownloadTag { get; private set; }
@@ -1409,6 +1518,11 @@ internal class Program
         public string? FirmwareHexPath { get; private set; }
         public string? FirmwareUpdateLatestDirectory { get; private set; }
         public bool LanChipInfo { get; private set; }
+        public bool MimicDesktop { get; private set; }
+        public int MimicDesktopChannels { get; private set; } = 16;
+        public int MimicDesktopFrequency { get; private set; } = 100;
+        public bool MimicDesktopSendDio { get; private set; }
+        public int MimicDesktopDelayMs { get; private set; }
         public List<string> Errors { get; } = new();
 
         public static CliOptions Parse(string[] args)
@@ -1499,6 +1613,9 @@ internal class Program
                     case "--sd-parse":
                         options.SdParsePath = GetValue(args, ref i, arg, options.Errors);
                         break;
+                    case "--sd-export-csv":
+                        options.SdExportCsvPath = GetValue(args, ref i, arg, options.Errors);
+                        break;
                     case "--sd-capture-parse":
                         options.CaptureAndParsePath = GetValue(args, ref i, arg, options.Errors);
                         break;
@@ -1523,6 +1640,21 @@ internal class Program
                         break;
                     case "--lan-chip-info":
                         options.LanChipInfo = true;
+                        break;
+                    case "--mimic-desktop":
+                        options.MimicDesktop = true;
+                        break;
+                    case "--mimic-desktop-channels":
+                        options.MimicDesktopChannels = GetIntValue(args, ref i, arg, options.Errors, 16);
+                        break;
+                    case "--mimic-desktop-freq":
+                        options.MimicDesktopFrequency = GetIntValue(args, ref i, arg, options.Errors, 100);
+                        break;
+                    case "--mimic-desktop-send-dio":
+                        options.MimicDesktopSendDio = true;
+                        break;
+                    case "--mimic-desktop-delay-ms":
+                        options.MimicDesktopDelayMs = GetIntValue(args, ref i, arg, options.Errors, 0);
                         break;
                     case "-h":
                     case "--help":

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a lightweight CLI that demonstrates how to use `Daqifi.Core` to discover
 
 ## Requirements
 
-- .NET 8 SDK
+- .NET 9 SDK
 - A DAQiFi device reachable via WiFi or USB/Serial
 - SD card operations require a USB/Serial connection (not available over WiFi)
 

--- a/SdCardSampleSource.cs
+++ b/SdCardSampleSource.cs
@@ -1,0 +1,96 @@
+using System.Runtime.CompilerServices;
+using Daqifi.Core.Channel;
+using Daqifi.Core.Device.SdCard;
+using Daqifi.Core.Logging.Export;
+
+namespace Daqifi.Core.Cli;
+
+/// <summary>
+/// Adapts an <see cref="SdCardLogSession"/> to <see cref="ISampleSource"/> so the core CSV
+/// exporter can consume SD card log files. Emits one column per analog channel and one
+/// column for the digital port (as the raw uint value).
+/// </summary>
+internal sealed class SdCardSampleSource : ISampleSource
+{
+    private const string DeviceName = "Daqifi";
+    private const string DigitalChannelName = "DIO";
+
+    private readonly SdCardLogSession _session;
+    private readonly List<ChannelDescriptor> _channels;
+    private readonly string[] _analogKeys;
+    private readonly string _digitalKey;
+
+    public SdCardSampleSource(SdCardLogSession session, int analogPortCount)
+    {
+        _session = session;
+        var serial = session.DeviceConfig?.DeviceSerialNumber ?? "unknown";
+
+        _channels = new List<ChannelDescriptor>(analogPortCount + 1);
+        _analogKeys = new string[analogPortCount];
+        for (var i = 0; i < analogPortCount; i++)
+        {
+            var name = $"AI{i}";
+            var descriptor = new ChannelDescriptor(DeviceName, serial, name, ChannelType.Analog);
+            _channels.Add(descriptor);
+            _analogKeys[i] = descriptor.Key;
+        }
+
+        var digital = new ChannelDescriptor(DeviceName, serial, DigitalChannelName, ChannelType.Digital);
+        _channels.Add(digital);
+        _digitalKey = digital.Key;
+    }
+
+    public IReadOnlyList<ChannelDescriptor> GetChannels() => _channels;
+
+    public ValueTask<int> GetSampleCountAsync(CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(0);
+
+    public async IAsyncEnumerable<SampleRow> StreamSamples(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var entry in _session.Samples.WithCancellation(cancellationToken))
+        {
+            var ticks = entry.Timestamp.Ticks;
+            var count = Math.Min(entry.AnalogValues.Count, _analogKeys.Length);
+            for (var i = 0; i < count; i++)
+            {
+                yield return new SampleRow(ticks, _analogKeys[i], entry.AnalogValues[i]);
+            }
+
+            yield return new SampleRow(ticks, _digitalKey, entry.DigitalData);
+        }
+    }
+}
+
+/// <summary>
+/// Wraps any <see cref="ISampleSource"/> and invokes a callback after each sample, used by the
+/// CLI to drive a throughput-aware progress display without changing the underlying source.
+/// </summary>
+internal sealed class CountingSampleSource : ISampleSource
+{
+    private readonly ISampleSource _inner;
+    private readonly Action<long> _onSample;
+
+    public CountingSampleSource(ISampleSource inner, Action<long> onSample)
+    {
+        _inner = inner;
+        _onSample = onSample;
+    }
+
+    public IReadOnlyList<ChannelDescriptor> GetChannels() => _inner.GetChannels();
+
+    public ValueTask<int> GetSampleCountAsync(CancellationToken cancellationToken = default)
+        => _inner.GetSampleCountAsync(cancellationToken);
+
+    public async IAsyncEnumerable<SampleRow> StreamSamples(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        long count = 0;
+        await foreach (var sample in _inner.StreamSamples(cancellationToken))
+        {
+            count++;
+            _onSample(count);
+            yield return sample;
+        }
+    }
+}

--- a/SdCardSampleSource.cs
+++ b/SdCardSampleSource.cs
@@ -48,9 +48,19 @@ internal sealed class SdCardSampleSource : ISampleSource
     public async IAsyncEnumerable<SampleRow> StreamSamples(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        var truncationWarned = false;
+
         await foreach (var entry in _session.Samples.WithCancellation(cancellationToken))
         {
             var ticks = entry.Timestamp.Ticks;
+            if (!truncationWarned && entry.AnalogValues.Count > _analogKeys.Length)
+            {
+                Console.Error.WriteLine(
+                    $"Warning: sample has {entry.AnalogValues.Count} analog values but configured channel count is " +
+                    $"{_analogKeys.Length}; extra channels will not appear in the CSV.");
+                truncationWarned = true;
+            }
+
             var count = Math.Min(entry.AnalogValues.Count, _analogKeys.Length);
             for (var i = 0; i < count; i++)
             {


### PR DESCRIPTION
## Summary

Adds a new CLI command to export an SD card log file as CSV using `Daqifi.Core`'s new `CsvExporter`. This demonstrates a second consumer of the export pipeline beyond `daqifi-desktop` and validates the storage-agnostic `ISampleSource` abstraction (which was the rationale for keeping the exporter in core).

```bash
# Capture an SD-format file from a connected device, then export to CSV:
dotnet run -- --serial /dev/cu.usbmodem101 --sd-capture-parse session.bin --duration 30
dotnet run -- --sd-parse session.bin --sd-export-csv session.csv
```

## Implementation

- **`SdCardSampleSource`** (new file) — `ISampleSource` adapter over `SdCardLogSession`. Emits one column per analog channel (`AI0`..`AIn`) plus one `DIO` column holding the raw uint digital-port value.
- When the parsed file lacks a status message (so `DeviceConfig` is null), the export path peeks the first sample's `AnalogValues.Count` to determine analog port count, then prepends that sample back into the stream so no data is lost.
- Reports samples/sec and MB/s throughput on completion.
- TFM bumped from `net8.0` to `net9.0` because `Daqifi.Core` drops `net8.0` support starting in 0.20.0.

## Test plan

Validated end-to-end against a serial-connected device (`/dev/cu.usbmodem101`, FW 3.2.0):

- [x] 30-second capture at 100 Hz with all 16 analog channels + DIO produces a 3000-row CSV (1 header + 2999 data rows × 17 columns)
- [x] Timestamps in ISO 8601 format match the live-stream output
- [x] Values match the live-stream output
- [x] Throughput end-to-end (parse + export): ~1.16M sample rows/sec, ~4 MB/s CSV write — 30s of device data exported in 0.04s

## Blocked on

- daqifi/daqifi-core#167 — must merge first to introduce `CsvExporter` / `ISampleSource`
- New `Daqifi.Core` NuGet release (0.20.0 or whatever ships next) — current published 0.19.7 doesn't have these types

After both land, this PR's `<PackageReference>` will need a version bump (currently still `0.19.4`); local builds via `-p:DaqifiCoreProjectPath=...` already work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)