### PR TITLE
feat: typed catches for SD card exceptions

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -845,6 +845,26 @@ internal class Program
 
             return 0;
         }
+        catch (SdCardNotPresentException)
+        {
+            Console.Error.WriteLine("No SD card is installed in the device.");
+            return 1;
+        }
+        catch (SdCardFilesystemException ex)
+        {
+            Console.Error.WriteLine($"SD card filesystem error: {ex.DeviceMessage}");
+            Console.Error.WriteLine("  Try a freshly FAT32-formatted card.");
+            return 1;
+        }
+        catch (SdCardOperationException ex)
+        {
+            Console.Error.WriteLine($"SD card error: {ex.Message}");
+            if (ex.LastScpiError is not null)
+            {
+                Console.Error.WriteLine($"  Device reported: {ex.LastScpiError}");
+            }
+            return 1;
+        }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"Error: {FormatException(ex)}");


### PR DESCRIPTION
## Summary

Demonstrates the new SD card exception hierarchy from [daqifi/daqifi-core#182](https://github.com/daqifi/daqifi-core/pull/182) by adding typed catches around the `--sd-*` operation block in `RunSdCardOperationAsync`.

```csharp
catch (SdCardNotPresentException)         // "No SD card is installed in the device."
catch (SdCardFilesystemException ex)      // device's filesystem error + FAT32 hint
catch (SdCardOperationException ex)       // generic SCPI failure + LastScpiError
catch (Exception ex)                      // existing fallback (unchanged)
```

The existing generic `catch (Exception)` is preserved as a fallback. No behavior change for the happy path or for non-SD operations.

## Why draft

This PR depends on a Daqifi.Core release that includes [daqifi-core#182](https://github.com/daqifi/daqifi-core/pull/182). The example app currently pins to `Daqifi.Core 0.20.0`, where these exception types do not yet exist. Once Core ships these types in the next release, this PR can be undrafted, the package version bumped, and merged.

## Test plan

- [x] Builds cleanly when pointed at the Core branch (`-p:DaqifiCoreProjectPath=...`)
- [x] Smoke-tested against `/dev/cu.usbmodem2101` — happy path unchanged (returns files; LAN restored)
- [ ] Re-test no-card path once Core is released and the package reference is bumped (verified earlier with worktree build: throws `SdCardNotPresentException` and prints "No SD card is installed in the device.")
- [ ] Re-test corrupt-FS path once a card that triggers `Failed to open directory` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
