### PR TITLE
feat: add --watch continuous-discovery mode (ContinuousDeviceFinder demo)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -43,17 +43,8 @@ internal class Program
             return 1;
         }
 
-        if (options.Discover)
-        {
-            await DiscoverAsync(options.DiscoveryTimeoutSeconds);
-        }
-
-        if (options.DiscoverSerial)
-        {
-            await DiscoverSerialDevicesAsync(options.DiscoveryTimeoutSeconds);
-        }
-
-        // Continuous "watch" mode owns its own exit code, so return early.
+        // Continuous "watch" mode owns its own exit code and is a dedicated dispatch
+        // path: handle it before one-shot discovery so the two never run together.
         if (options.Watch && options.WatchSerial)
         {
             Console.Error.WriteLine("Cannot specify both --watch and --watch-serial. Use one or the other.");
@@ -68,6 +59,16 @@ internal class Program
         if (options.WatchSerial)
         {
             return await RunWatchAsync(new SerialDeviceFinder(), options);
+        }
+
+        if (options.Discover)
+        {
+            await DiscoverAsync(options.DiscoveryTimeoutSeconds);
+        }
+
+        if (options.DiscoverSerial)
+        {
+            await DiscoverSerialDevicesAsync(options.DiscoveryTimeoutSeconds);
         }
 
         // SD card file parse is a local-only operation (no device needed)
@@ -657,11 +658,25 @@ internal class Program
 
     private static async Task<int> RunWatchAsync(IDeviceFinder finder, CliOptions options)
     {
-        var durationSeconds = options.DurationSeconds > 0 ? options.DurationSeconds : DefaultDurationSeconds;
+        // A positive --duration auto-stops the watch; <= 0 means run until Ctrl+C,
+        // matching how streaming and SD logging treat DurationSeconds in this CLI.
+        var bounded = options.DurationSeconds > 0;
 
-        Console.WriteLine($"Watching for devices for {durationSeconds}s (Ctrl+C to stop early)...");
+        if (bounded)
+        {
+            Console.WriteLine($"Watching for devices for {options.DurationSeconds}s (Ctrl+C to stop early)...");
+        }
+        else
+        {
+            Console.WriteLine("Watching for devices (Ctrl+C to stop)...");
+        }
+
         Console.WriteLine("Legend: [+] discovered, [-] lost");
         Console.WriteLine();
+
+        // Surface operational errors (scan failures, a failed stop) via the exit code so
+        // scripts/CI don't read a clean exit as success, consistent with the other handlers.
+        var hadError = false;
 
         // ContinuousDeviceFinder owns and disposes the inner finder (LeaveInnerFinderOpen = false),
         // so a single using covers both.
@@ -686,25 +701,20 @@ internal class Program
 
         watcher.ScanError += (_, args) =>
         {
+            hadError = true;
             Console.Error.WriteLine($"Scan error: {args.Exception.Message}");
         };
 
-        try
-        {
-            watcher.Start();
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"Error: {FormatException(ex)}");
-            return 1;
-        }
-
         using var stopCts = new CancellationTokenSource();
-        stopCts.CancelAfter(TimeSpan.FromSeconds(durationSeconds));
+        if (bounded)
+        {
+            stopCts.CancelAfter(TimeSpan.FromSeconds(options.DurationSeconds));
+        }
 
-        // Hold a reference so the handler can be removed in the finally below. CancelKeyPress
-        // is a process-global event, so a handler left subscribed would leak (and could fire
-        // against a disposed token) if watch mode runs more than once in-process.
+        // Register Ctrl+C BEFORE starting the scan so an early Ctrl+C triggers graceful
+        // shutdown instead of killing the process. CancelKeyPress is a process-global event,
+        // so we remove the handler again in the outer finally (it would otherwise leak and
+        // could fire against a disposed token if watch mode runs more than once in-process).
         ConsoleCancelEventHandler cancelHandler = (_, e) =>
         {
             e.Cancel = true;
@@ -716,25 +726,42 @@ internal class Program
 
         try
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan, stopCts.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected: duration elapsed or Ctrl+C pressed.
+            try
+            {
+                watcher.Start();
+            }
+            catch (Exception ex)
+            {
+                // Never started, so there is nothing to stop; the outer finally unsubscribes.
+                Console.Error.WriteLine($"Error: {FormatException(ex)}");
+                return 1;
+            }
+
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, stopCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected: duration elapsed or Ctrl+C pressed.
+            }
+            finally
+            {
+                // Always stop the scan loop, even if the wait above threw unexpectedly.
+                try
+                {
+                    await watcher.StopAsync();
+                }
+                catch (Exception ex)
+                {
+                    hadError = true;
+                    Console.Error.WriteLine($"Error stopping watcher: {FormatException(ex)}");
+                }
+            }
         }
         finally
         {
             Console.CancelKeyPress -= cancelHandler;
-
-            // Always stop the scan loop, even if the wait above threw unexpectedly.
-            try
-            {
-                await watcher.StopAsync();
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"Error stopping watcher: {FormatException(ex)}");
-            }
         }
 
         var live = watcher.Devices;
@@ -745,7 +772,7 @@ internal class Program
             Console.WriteLine($"  - {d.Name} SN:{d.SerialNumber} ({DescribeEndpoint(d)})");
         }
 
-        return 0;
+        return hadError ? 1 : 0;
     }
 
     // Renders whichever endpoint the transport populated (IP for WiFi, port for serial).

--- a/Program.cs
+++ b/Program.cs
@@ -53,6 +53,17 @@ internal class Program
             await DiscoverSerialDevicesAsync(options.DiscoveryTimeoutSeconds);
         }
 
+        // Continuous "watch" mode owns its own exit code, so return early.
+        if (options.Watch)
+        {
+            return await RunWatchAsync(new WiFiDeviceFinder(), options);
+        }
+
+        if (options.WatchSerial)
+        {
+            return await RunWatchAsync(new SerialDeviceFinder(), options);
+        }
+
         // SD card file parse is a local-only operation (no device needed)
         if (!string.IsNullOrWhiteSpace(options.SdParsePath))
         {
@@ -635,6 +646,92 @@ internal class Program
                 Console.WriteLine($"  - {device.Name} ({device.PortName}) SN:{device.SerialNumber} FW:{device.FirmwareVersion}");
             }
         }
+    }
+
+    private static async Task<int> RunWatchAsync(IDeviceFinder finder, CliOptions options)
+    {
+        var durationSeconds = options.DurationSeconds > 0 ? options.DurationSeconds : DefaultDurationSeconds;
+
+        Console.WriteLine($"Watching for devices for {durationSeconds}s (Ctrl+C to stop early)...");
+        Console.WriteLine("Legend: [+] discovered, [-] lost");
+        Console.WriteLine();
+
+        // ContinuousDeviceFinder owns and disposes the inner finder (LeaveInnerFinderOpen = false),
+        // so a single using covers both.
+        using var watcher = new ContinuousDeviceFinder(finder, new ContinuousDiscoveryOptions
+        {
+            Interval = TimeSpan.FromSeconds(1),
+            PassTimeout = TimeSpan.FromSeconds(3),
+            MissThreshold = 2,
+        });
+
+        watcher.DeviceDiscovered += (_, args) =>
+        {
+            var d = args.DeviceInfo;
+            Console.WriteLine($"  [+] discovered {d.Name} SN:{d.SerialNumber} ({DescribeEndpoint(d)})");
+        };
+
+        watcher.DeviceLost += (_, args) =>
+        {
+            var d = args.DeviceInfo;
+            Console.WriteLine($"  [-] lost       {d.Name} SN:{d.SerialNumber} ({DescribeEndpoint(d)})");
+        };
+
+        watcher.ScanError += (_, args) =>
+        {
+            Console.Error.WriteLine($"Scan error: {args.Exception.Message}");
+        };
+
+        try
+        {
+            watcher.Start();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {FormatException(ex)}");
+            return 1;
+        }
+
+        using var stopCts = new CancellationTokenSource();
+        stopCts.CancelAfter(TimeSpan.FromSeconds(durationSeconds));
+        Console.CancelKeyPress += (_, e) => { e.Cancel = true; stopCts.Cancel(); };
+
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, stopCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: duration elapsed or Ctrl+C pressed.
+        }
+
+        await watcher.StopAsync();
+
+        var live = watcher.Devices;
+        Console.WriteLine();
+        Console.WriteLine($"Final live set: {live.Count} device(s)");
+        foreach (var d in live)
+        {
+            Console.WriteLine($"  - {d.Name} SN:{d.SerialNumber} ({DescribeEndpoint(d)})");
+        }
+
+        return 0;
+    }
+
+    // Renders whichever endpoint the transport populated (IP for WiFi, port for serial).
+    private static string DescribeEndpoint(IDeviceInfo device)
+    {
+        if (!string.IsNullOrWhiteSpace(device.PortName))
+        {
+            return device.PortName!;
+        }
+
+        if (device.IPAddress != null)
+        {
+            return $"{device.IPAddress}:{device.Port}";
+        }
+
+        return device.ConnectionType.ToString();
     }
 
     private static async Task<int> RunSdCardOperationAsync(CliOptions options)
@@ -1401,6 +1498,8 @@ internal class Program
         Console.WriteLine("  -d, --discover           Discover WiFi devices over UDP.");
         Console.WriteLine("  --discover-serial        List available serial ports.");
         Console.WriteLine("  --discover-timeout <s>   WiFi discovery timeout in seconds (default: 5).");
+        Console.WriteLine("  --watch                  Continuously watch for WiFi devices (live +/- updates), bounded by --duration.");
+        Console.WriteLine("  --watch-serial           Continuously watch for serial devices (live +/- updates), bounded by --duration.");
         Console.WriteLine();
         Console.WriteLine("Streaming Options:");
         Console.WriteLine($"  --rate <hz>              Streaming rate in Hz (default: {DefaultRate}).");
@@ -1468,6 +1567,8 @@ internal class Program
     {
         public bool Discover { get; private set; }
         public bool DiscoverSerial { get; private set; }
+        public bool Watch { get; private set; }
+        public bool WatchSerial { get; private set; }
         public string? IpAddress { get; private set; }
         public int Port { get; private set; } = DefaultPort;
         public string? SerialPort { get; private set; }
@@ -1519,6 +1620,12 @@ internal class Program
                         break;
                     case "--discover-serial":
                         options.DiscoverSerial = true;
+                        break;
+                    case "--watch":
+                        options.Watch = true;
+                        break;
+                    case "--watch-serial":
+                        options.WatchSerial = true;
                         break;
                     case "--ip":
                         options.IpAddress = GetValue(args, ref i, arg, options.Errors);

--- a/Program.cs
+++ b/Program.cs
@@ -54,6 +54,12 @@ internal class Program
         }
 
         // Continuous "watch" mode owns its own exit code, so return early.
+        if (options.Watch && options.WatchSerial)
+        {
+            Console.Error.WriteLine("Cannot specify both --watch and --watch-serial. Use one or the other.");
+            return 1;
+        }
+
         if (options.Watch)
         {
             return await RunWatchAsync(new WiFiDeviceFinder(), options);
@@ -694,7 +700,18 @@ internal class Program
 
         using var stopCts = new CancellationTokenSource();
         stopCts.CancelAfter(TimeSpan.FromSeconds(durationSeconds));
-        Console.CancelKeyPress += (_, e) => { e.Cancel = true; stopCts.Cancel(); };
+
+        // Hold a reference so the handler can be removed in the finally below. CancelKeyPress
+        // is a process-global event, so a handler left subscribed would leak (and could fire
+        // against a disposed token) if watch mode runs more than once in-process.
+        ConsoleCancelEventHandler cancelHandler = (_, e) =>
+        {
+            e.Cancel = true;
+            // Ctrl+C fires on its own thread and can race shutdown disposing stopCts.
+            try { stopCts.Cancel(); }
+            catch (ObjectDisposedException) { /* already shutting down */ }
+        };
+        Console.CancelKeyPress += cancelHandler;
 
         try
         {
@@ -704,8 +721,20 @@ internal class Program
         {
             // Expected: duration elapsed or Ctrl+C pressed.
         }
+        finally
+        {
+            Console.CancelKeyPress -= cancelHandler;
 
-        await watcher.StopAsync();
+            // Always stop the scan loop, even if the wait above threw unexpectedly.
+            try
+            {
+                await watcher.StopAsync();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error stopping watcher: {FormatException(ex)}");
+            }
+        }
 
         var live = watcher.Devices;
         Console.WriteLine();

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ dotnet run -- \
 ## Options
 
 - `--discover` discover devices over UDP
+- `--watch` continuously watch for WiFi devices (live `[+]`/`[-]` updates), bounded by `--duration`
+- `--watch-serial` continuously watch for serial devices (live `[+]`/`[-]` updates), bounded by `--duration`
 - `--ip <address>` device IP address
 - `--port <number>` TCP port (default 9760)
 - `--rate <hz>` sampling rate in Hz (default 100)
@@ -55,6 +57,27 @@ dotnet run -- \
 - `--fw-update-hex <path>` run PIC32 firmware update from a local Intel HEX file (USB/Serial only)
 - `--fw-update-latest <dir>` download latest PIC32 firmware HEX to `<dir>`, then run update (USB/Serial only)
 - `--lan-chip-info` query the WiFi module chip ID, firmware version, and build date (USB/Serial only)
+
+## Watch Mode (Continuous Discovery)
+
+Unlike one-shot `--discover`/`--discover-serial`, watch mode keeps a live, deduplicated
+device set and prints `[+] discovered` / `[-] lost` transitions as devices appear and
+disappear. The run is bounded by `--duration` and can be stopped early with Ctrl+C.
+
+Watch for serial devices for 30 seconds:
+
+```bash
+dotnet run -- --watch-serial --duration 30
+```
+
+Watch for WiFi devices:
+
+```bash
+dotnet run -- --watch --duration 30
+```
+
+Unplug/replug a device during the run to confirm the `[-] lost` line fires (after the
+miss threshold of consecutive missed passes). On exit, the final live set is printed.
 
 ## SD Card
 


### PR DESCRIPTION
## Summary

Adds a continuous-discovery **watch** mode to the example CLI that demonstrates the `ContinuousDeviceFinder` API from `Daqifi.Core` — a stateful live device set with `DeviceDiscovered` / `DeviceLost` events (core: [daqifi-core#248](https://github.com/daqifi/daqifi-core/pull/248), shipped in **0.24.0**).

Two flags mirroring the existing discovery pair, bounded by `--duration`:

- `--watch` — continuously watch for **WiFi** devices, printing live `[+] discovered` / `[-] lost` transitions.
- `--watch-serial` — same for **serial** devices.

Unlike one-shot `--discover`/`--discover-serial`, watch mode keeps a deduplicated live set across passes and surfaces the genuinely new behavior — a device being **lost** after it stops responding.

All changes are in `Program.cs` (new `CliOptions` flags, parse arms, `Main` dispatch, `--help` lines, `RunWatchAsync` + `DescribeEndpoint` handlers) plus README docs.

## Daqifi.Core dependency

`ContinuousDeviceFinder` / `ContinuousDiscoveryOptions` shipped in **Daqifi.Core 0.24.0** ([daqifi-core#248](https://github.com/daqifi/daqifi-core/pull/248)), now published on NuGet. This branch is merged up to current `main` (includes #31) and the package reference is bumped `0.20.0 → 0.24.0`. The default `dotnet build` restores cleanly against the published package (0 warnings / 0 errors).

A fresh real-hardware bench run (against published 0.24.0) is posted in the comments.

## Acceptance criteria

- [x] `--watch` and `--watch-serial` flags added, parsed, dispatched, and documented in `--help`.
- [x] Live `[+] discovered` / `[-] lost` lines print as devices appear/disappear; run bounded by `--duration` and stoppable with Ctrl+C.
- [x] Final live-set summary printed on exit; exit code 0 on success.
- [x] Manually verified against real hardware, including the lost-device transition (unplug mid-run).

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
