### PR TITLE
feat: add --sd-storage command to query SD card space

### DIFF
--- a/Daqifi.Core.Cli.csproj
+++ b/Daqifi.Core.Cli.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DaqifiCoreProjectPath)' == ''">
-    <PackageReference Include="Daqifi.Core" Version="0.20.0" />
+    <PackageReference Include="Daqifi.Core" Version="0.24.0" />
   </ItemGroup>
 
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1428,8 +1428,8 @@ internal class Program
         Console.WriteLine("  --show-status            Print protobuf status messages when received.");
         Console.WriteLine();
         Console.WriteLine("SD Card Options:");
-        Console.WriteLine("  --sd-list                List files on the SD card.");
-        Console.WriteLine("  --sd-storage             Show SD card free/used/total space.");
+        Console.WriteLine("  --sd-list                List files on the SD card (USB/serial only).");
+        Console.WriteLine("  --sd-storage             Show SD card free/used/total space (USB/serial only).");
         Console.WriteLine("  --sd-log-start           Start SD card logging (use --duration to auto-stop).");
         Console.WriteLine("  --sd-log-format <fmt>    Log format: protobuf (default), json, csv.");
         Console.WriteLine("  --sd-log-stop            Stop SD card logging.");
@@ -1672,6 +1672,50 @@ internal class Program
             if (firmwareCommandCount > 1)
             {
                 options.Errors.Add("Specify only one firmware command at a time.");
+            }
+
+            // SD card device operations are dispatched via a single if/else-if chain in
+            // RunSdCardOperationAsync, so only one can actually run. Reject conflicting flags
+            // up front instead of silently ignoring all but the first.
+            var sdCommandCount = 0;
+            if (options.SdStorage)
+            {
+                sdCommandCount++;
+            }
+
+            if (options.SdList)
+            {
+                sdCommandCount++;
+            }
+
+            if (options.SdLogStart)
+            {
+                sdCommandCount++;
+            }
+
+            if (options.SdLogStop)
+            {
+                sdCommandCount++;
+            }
+
+            if (options.SdFormat)
+            {
+                sdCommandCount++;
+            }
+
+            if (options.SdDeleteFileName != null)
+            {
+                sdCommandCount++;
+            }
+
+            if (options.SdDownloadFileName != null)
+            {
+                sdCommandCount++;
+            }
+
+            if (sdCommandCount > 1)
+            {
+                options.Errors.Add("Specify only one SD card command at a time.");
             }
 
             if (!string.IsNullOrWhiteSpace(options.FirmwareDownloadTag) &&

--- a/Program.cs
+++ b/Program.cs
@@ -119,7 +119,8 @@ internal class Program
 
         // Route to SD card operations if any SD card flags are set
         if (options.SdList || options.SdLogStart || options.SdLogStop ||
-            options.SdDeleteFileName != null || options.SdDownloadFileName != null || options.SdFormat)
+            options.SdDeleteFileName != null || options.SdDownloadFileName != null ||
+            options.SdFormat || options.SdStorage)
         {
             return await RunSdCardOperationAsync(options);
         }
@@ -683,7 +684,19 @@ internal class Program
 
             await streamingDevice.InitializeAsync();
 
-            if (options.SdList)
+            if (options.SdStorage)
+            {
+                Console.WriteLine("Querying SD card storage...");
+                var storage = await streamingDevice.GetSdCardStorageAsync();
+                Console.WriteLine($"  Free:  {storage.FreeBytes,15:N0} bytes ({storage.FreeBytes / 1024.0 / 1024.0:F2} MiB)");
+                Console.WriteLine($"  Used:  {storage.UsedBytes,15:N0} bytes ({storage.UsedBytes / 1024.0 / 1024.0:F2} MiB)");
+                Console.WriteLine($"  Total: {storage.TotalBytes,15:N0} bytes ({storage.TotalBytes / 1024.0 / 1024.0:F2} MiB)");
+                if (storage.TotalBytes > 0)
+                {
+                    Console.WriteLine($"  Used%: {storage.UsedBytes * 100.0 / storage.TotalBytes:F1}%");
+                }
+            }
+            else if (options.SdList)
             {
                 Console.WriteLine("Listing SD card files...");
                 var files = await streamingDevice.GetSdCardFilesAsync();
@@ -1416,6 +1429,7 @@ internal class Program
         Console.WriteLine();
         Console.WriteLine("SD Card Options:");
         Console.WriteLine("  --sd-list                List files on the SD card.");
+        Console.WriteLine("  --sd-storage             Show SD card free/used/total space.");
         Console.WriteLine("  --sd-log-start           Start SD card logging (use --duration to auto-stop).");
         Console.WriteLine("  --sd-log-format <fmt>    Log format: protobuf (default), json, csv.");
         Console.WriteLine("  --sd-log-stop            Stop SD card logging.");
@@ -1493,6 +1507,7 @@ internal class Program
         public string? SdDeleteFileName { get; private set; }
         public string? SdDownloadFileName { get; private set; }
         public bool SdFormat { get; private set; }
+        public bool SdStorage { get; private set; }
         public string? SdParsePath { get; set; }
         public string? SdExportCsvPath { get; private set; }
         public string? CaptureAndParsePath { get; private set; }
@@ -1588,6 +1603,9 @@ internal class Program
                         break;
                     case "--sd-format":
                         options.SdFormat = true;
+                        break;
+                    case "--sd-storage":
+                        options.SdStorage = true;
                         break;
                     case "--sd-parse":
                         options.SdParsePath = GetValue(args, ref i, arg, options.Errors);

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ dotnet run -- \
 - `--show-status` print protobuf status messages
 - `--discover-timeout <seconds>` discovery timeout (default 5)
 - `--sd-list` list files on the SD card (USB/Serial only)
+- `--sd-storage` show SD card free/used/total space (USB/Serial only)
 - `--sd-log-start` start SD card logging (USB/Serial only)
 - `--sd-log-stop` stop SD card logging (USB/Serial only)
 - `--sd-download <filename>` download a file from the SD card and parse it (USB/Serial only)


### PR DESCRIPTION
## Summary

Adds a `--sd-storage` command that queries the SD card's free/used/total space via `GetSdCardStorageAsync()` and prints a formatted summary:

```
Querying SD card storage...
  Free:    7,810,023,424 bytes (7448.22 MiB)
  Used:        5,111,808 bytes (4.88 MiB)
  Total:   7,815,135,232 bytes (7453.09 MiB)
  Used%: 0.1%
```

Includes the help-text entry and a README line.

## Daqifi.Core dependency

`GetSdCardStorageAsync` was added in [daqifi-core#214](https://github.com/daqifi/daqifi-core/pull/214) and shipped in **Daqifi.Core 0.24.0** (now published on NuGet). This PR bumps the package reference `0.20.0 → 0.24.0`. The default `dotnet build` restores cleanly against the published package (0 warnings / 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
