### PR TITLE
fix(cli): clean connect errors, honest CSV row counts, real download paths, working --show-status (closes #39, #40, #41, #42)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1009,35 +1009,45 @@ internal class Program
                 var destinationPath = sdDownloadDestination!;
                 SdCardDownloadResult result;
 
-                // Tracks whether this process actually created the file, so the cleanup below can
-                // never delete a file someone else created between the check above and the open.
-                var createdDestination = false;
+                // Download into a sibling temporary file and publish it only once the transfer has
+                // completed. Writing straight to the destination would mean a stalled or failed
+                // download destroys whatever was already there (with --overwrite, the moment the
+                // file is opened) or leaves a partial one that looks like a good download. A
+                // sibling rather than the system temp directory keeps the publish step a
+                // same-volume rename instead of a cross-device copy.
+                var tempPath = $"{destinationPath}.part-{Guid.NewGuid():N}";
                 try
                 {
-                    // CreateNew rather than Create: the destination was checked above, and this
-                    // closes the race so a concurrent writer's file is never truncated. With
-                    // --overwrite the user has explicitly accepted replacing whatever is there.
-                    await using var destinationStream = new FileStream(
-                        destinationPath,
-                        options.Overwrite ? FileMode.Create : FileMode.CreateNew,
+                    await using (var destinationStream = new FileStream(
+                        tempPath,
+                        FileMode.CreateNew,
                         FileAccess.Write,
                         FileShare.None,
                         bufferSize: 65536,
-                        useAsync: true);
-                    createdDestination = true;
+                        useAsync: true))
+                    {
+                        result = await streamingDevice.DownloadSdCardFileAsync(
+                            options.SdDownloadFileName, destinationStream, progress);
+                    }
 
-                    result = await streamingDevice.DownloadSdCardFileAsync(
-                        options.SdDownloadFileName, destinationStream, progress);
+                    // A single rename on both POSIX and Windows, so the destination is never
+                    // observed missing or half-written. The two-argument overload throws if the
+                    // destination appeared while the transfer was running, which is the race guard
+                    // that opening with CreateNew used to provide.
+                    if (options.Overwrite)
+                    {
+                        File.Move(tempPath, destinationPath, overwrite: true);
+                    }
+                    else
+                    {
+                        File.Move(tempPath, destinationPath);
+                    }
                 }
                 catch
                 {
-                    // A failed transfer leaves a partial (often empty) file behind, which is easy
-                    // to mistake for a good download. Remove it and let the error propagate.
-                    if (createdDestination)
-                    {
-                        try { File.Delete(destinationPath); } catch { /* best effort */ }
-                    }
-
+                    // Only ever removes our own temp file; the destination is untouched unless the
+                    // rename above already succeeded.
+                    try { File.Delete(tempPath); } catch { /* best effort */ }
                     throw;
                 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -837,6 +837,7 @@ internal class Program
             sdDownloadDestination = ResolveSdDownloadDestination(
                 options.SdDownloadFileName,
                 options.SdDownloadDestination,
+                options.Overwrite,
                 out var destinationError);
 
             if (sdDownloadDestination is null)
@@ -1014,10 +1015,11 @@ internal class Program
                 try
                 {
                     // CreateNew rather than Create: the destination was checked above, and this
-                    // closes the race so a concurrent writer's file is never truncated.
+                    // closes the race so a concurrent writer's file is never truncated. With
+                    // --overwrite the user has explicitly accepted replacing whatever is there.
                     await using var destinationStream = new FileStream(
                         destinationPath,
-                        FileMode.CreateNew,
+                        options.Overwrite ? FileMode.Create : FileMode.CreateNew,
                         FileAccess.Write,
                         FileShare.None,
                         bufferSize: 65536,
@@ -1043,9 +1045,11 @@ internal class Program
                 Console.WriteLine($"Download complete: {result.FileSize:N0} bytes in {result.Duration.TotalSeconds:F1}s");
                 Console.WriteLine($"Saved to: {destinationPath}");
 
-                // Parse the downloaded file (any supported format)
-                var downloadExt = Path.GetExtension(destinationPath).ToLowerInvariant();
-                if (downloadExt is ".bin" or ".csv" or ".json")
+                // Parse the downloaded file (any supported format). The format is a property of the
+                // file's name on the device, not of wherever the user chose to save it — otherwise
+                // a --sd-download-to path with no extension (or a different one) would silently
+                // skip the parse that --sd-download documents.
+                if (IsParseableLogFile(options.SdDownloadFileName))
                 {
                     Console.WriteLine();
                     Console.WriteLine("--- Parsing downloaded file ---");
@@ -1054,7 +1058,7 @@ internal class Program
                     // Pass the connected device's config so the parser can
                     // scale raw ADC values using the device's calibration.
                     var deviceConfig = SdCardDeviceConfiguration.FromDevice((DaqifiDevice)device);
-                    return await RunSdCardParseAsync(options, deviceConfig);
+                    return await RunSdCardParseAsync(options, deviceConfig, options.SdDownloadFileName);
                 }
             }
             else if (options.SdFormat)
@@ -1098,11 +1102,13 @@ internal class Program
     /// </summary>
     /// <param name="sourceFileName">The file name on the device's SD card.</param>
     /// <param name="requestedDestination">The <c>--sd-download-to</c> value, if any.</param>
+    /// <param name="allowOverwrite">Whether <c>--overwrite</c> was given.</param>
     /// <param name="error">Set to the message to print when the destination is unusable.</param>
     /// <returns>The absolute destination path, or <c>null</c> when it is unusable.</returns>
     private static string? ResolveSdDownloadDestination(
         string sourceFileName,
         string? requestedDestination,
+        bool allowOverwrite,
         out string? error)
     {
         error = null;
@@ -1148,10 +1154,10 @@ internal class Program
             return null;
         }
 
-        if (File.Exists(destinationPath))
+        if (!allowOverwrite && File.Exists(destinationPath))
         {
             error = $"Destination already exists: {destinationPath}. " +
-                    "Use --sd-download-to <path> to write somewhere else, or remove the existing file.";
+                    "Pass --overwrite to replace it, or use --sd-download-to <path> to write somewhere else.";
             return null;
         }
 
@@ -1165,14 +1171,28 @@ internal class Program
         return destinationPath;
     }
 
+    /// <summary>
+    /// Whether <paramref name="fileName"/> names a log format the parser understands.
+    /// </summary>
+    private static bool IsParseableLogFile(string fileName)
+        => SdCardFileParserFactory.TryDetectFormat(fileName, out _);
+
     private static bool EndsWithDirectorySeparator(string path)
     {
         return path.EndsWith(Path.DirectorySeparatorChar) || path.EndsWith(Path.AltDirectorySeparatorChar);
     }
 
+    /// <param name="options">Parsed CLI options; <c>SdParsePath</c> selects the file to read.</param>
+    /// <param name="deviceConfig">Optional live device configuration used to scale raw ADC values.</param>
+    /// <param name="sourceFileName">
+    /// The name the file had on the device, when it was just downloaded. The format and the logging
+    /// date are read from this name rather than from the local path, so saving under a different
+    /// name (or none) via <c>--sd-download-to</c> does not change how the file is parsed.
+    /// </param>
     private static async Task<int> RunSdCardParseAsync(
         CliOptions options,
-        SdCardDeviceConfiguration? deviceConfig = null)
+        SdCardDeviceConfiguration? deviceConfig = null,
+        string? sourceFileName = null)
     {
         var filePath = options.SdParsePath!;
         if (!File.Exists(filePath))
@@ -1181,10 +1201,13 @@ internal class Program
             return 1;
         }
 
+        // When the file was downloaded, its identity for parsing purposes is the device-side name.
+        var formatSourceName = sourceFileName ?? filePath;
+
         SdCardLogFormat format;
         try
         {
-            format = SdCardFileParserFactory.DetectFormat(filePath);
+            format = SdCardFileParserFactory.DetectFormat(formatSourceName);
         }
         catch (ArgumentException ex)
         {
@@ -1192,7 +1215,7 @@ internal class Program
             return 1;
         }
 
-        var formatLabel = GetLogFormatLabel(filePath);
+        var formatLabel = GetLogFormatLabel(format);
         Console.WriteLine($"Parsing {formatLabel} SD card log file: {filePath}");
 
         var parseOptions = new SdCardParseOptions
@@ -1210,7 +1233,23 @@ internal class Program
 
         try
         {
-            var session = await SdCardFileParserFactory.ParseFileAsync(filePath, parseOptions);
+            // Parsed with an explicit format rather than via ParseFileAsync, which would re-derive
+            // the format from the local path. Identical for a plain --sd-parse (the name passed for
+            // metadata is the same one ParseFileAsync would use); for a download it keeps the
+            // device-side name, so the format and the logging date survive --sd-download-to.
+            await using var parseStream = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                bufferSize: parseOptions.BufferSize,
+                useAsync: true);
+
+            var session = await SdCardFileParserFactory.ParseWithFormatAsync(
+                parseStream,
+                Path.GetFileName(formatSourceName),
+                format,
+                parseOptions);
             Console.WriteLine();
 
             Console.WriteLine($"File: {session.FileName}");
@@ -1671,6 +1710,17 @@ internal class Program
         };
     }
 
+    private static string GetLogFormatLabel(SdCardLogFormat format)
+    {
+        return format switch
+        {
+            SdCardLogFormat.Protobuf => "Protobuf",
+            SdCardLogFormat.Json => "JSON",
+            SdCardLogFormat.Csv => "CSV",
+            _ => "Unknown"
+        };
+    }
+
     private static bool IsValidChannelMask(string channelMask)
     {
         return uint.TryParse(channelMask, out _);
@@ -1718,7 +1768,8 @@ internal class Program
         Console.WriteLine("  --sd-delete <filename>   Delete a file from the SD card.");
         Console.WriteLine("  --sd-download <filename> Download a file from the SD card, saved as ./<filename>.");
         Console.WriteLine("  --sd-download-to <path>  Destination for --sd-download: a file path, or a directory to");
-        Console.WriteLine("                           save under the source file name. Never overwrites.");
+        Console.WriteLine("                           save under the source file name.");
+        Console.WriteLine("  --overwrite              Allow --sd-download to replace an existing destination file.");
         Console.WriteLine("  --sd-format              Format the SD card (erases all data).");
         Console.WriteLine("  --sd-parse <path>        Parse a .bin log file from the SD card.");
         Console.WriteLine("  --sd-export-csv <path>   With --sd-parse, write samples as CSV to <path> using Daqifi.Core's CsvExporter.");
@@ -1793,6 +1844,7 @@ internal class Program
         public string? SdDeleteFileName { get; private set; }
         public string? SdDownloadFileName { get; private set; }
         public string? SdDownloadDestination { get; private set; }
+        public bool Overwrite { get; private set; }
         public bool SdFormat { get; private set; }
         public bool SdStorage { get; private set; }
         public string? SdParsePath { get; set; }
@@ -1896,6 +1948,9 @@ internal class Program
                         break;
                     case "--sd-download-to":
                         options.SdDownloadDestination = GetValue(args, ref i, arg, options.Errors);
+                        break;
+                    case "--overwrite":
+                        options.Overwrite = true;
                         break;
                     case "--sd-format":
                         options.SdFormat = true;
@@ -2030,6 +2085,11 @@ internal class Program
                 string.IsNullOrWhiteSpace(options.SdDownloadFileName))
             {
                 options.Errors.Add("--sd-download-to requires --sd-download <filename>.");
+            }
+
+            if (options.Overwrite && string.IsNullOrWhiteSpace(options.SdDownloadFileName))
+            {
+                options.Errors.Add("--overwrite requires --sd-download <filename>.");
             }
 
             return options;

--- a/Program.cs
+++ b/Program.cs
@@ -25,6 +25,22 @@ internal class Program
 
     private static async Task<int> Main(string[] args)
     {
+        try
+        {
+            return await RunAsync(args);
+        }
+        catch (Exception ex)
+        {
+            // Last-resort guard. An exception that escapes Main aborts the process with SIGABRT
+            // (exit code 134) and dumps a stack trace, which reads as a tool defect rather than an
+            // expected operational failure. Report it the way every other failure path does.
+            Console.Error.WriteLine($"Error: {FormatException(ex)}");
+            return 1;
+        }
+    }
+
+    private static async Task<int> RunAsync(string[] args)
+    {
         var options = CliOptions.Parse(args);
         if (options.ShowHelp)
         {
@@ -151,9 +167,20 @@ internal class Program
         return await RunStreamingSessionAsync(options);
     }
 
-    private static async Task<int> RunStreamingSessionAsync(CliOptions options)
+    /// <summary>
+    /// A connected device together with the human-readable description of how it was reached.
+    /// </summary>
+    private sealed record Connection(DaqifiDevice Device, string Description);
+
+    /// <summary>
+    /// Connects to the device described by <paramref name="options"/> over serial or TCP.
+    /// </summary>
+    /// <returns>
+    /// The connection, or <c>null</c> when connecting failed — in which case a single-line error has
+    /// already been written to stderr and the caller should return exit code 1.
+    /// </returns>
+    private static async Task<Connection?> ConnectAsync(CliOptions options)
     {
-        // Build connection options from CLI parameters
         var connectionOptions = new DeviceConnectionOptions
         {
             ConnectionRetry = new ConnectionRetryOptions
@@ -164,26 +191,47 @@ internal class Program
             }
         };
 
-        // Connect via TCP or Serial based on provided options
-        DaqifiDevice device;
-        string connectionDescription;
+        var useSerial = !string.IsNullOrWhiteSpace(options.SerialPort);
+        var description = useSerial
+            ? $"{options.SerialPort} @ {options.BaudRate} baud"
+            : $"{options.IpAddress}:{options.Port}";
 
-        if (!string.IsNullOrWhiteSpace(options.SerialPort))
+        try
         {
-            device = await DaqifiDeviceFactory.ConnectSerialAsync(
-                options.SerialPort,
-                options.BaudRate,
-                connectionOptions);
-            connectionDescription = $"{options.SerialPort} @ {options.BaudRate} baud";
+            var device = useSerial
+                ? await DaqifiDeviceFactory.ConnectSerialAsync(
+                    options.SerialPort!,
+                    options.BaudRate,
+                    connectionOptions)
+                : await DaqifiDeviceFactory.ConnectTcpAsync(
+                    options.IpAddress!,
+                    options.Port,
+                    connectionOptions);
+
+            return new Connection(device, description);
         }
-        else
+        catch (Exception ex)
         {
-            device = await DaqifiDeviceFactory.ConnectTcpAsync(
-                options.IpAddress!,
-                options.Port,
-                connectionOptions);
-            connectionDescription = $"{options.IpAddress}:{options.Port}";
+            // Caught broadly on purpose. A failed connect is an ordinary outcome for a CLI (device
+            // unplugged, wrong port, wrong IP), and the transport layer surfaces it as any of a
+            // long and evolving list of exception types — IO, UnauthorizedAccess, Timeout, socket
+            // and argument errors among them. Catching the specific types would leave the crash in
+            // place for whichever one we did not list.
+            Console.Error.WriteLine($"Error: Could not connect to {description}: {FormatException(ex)}");
+            return null;
         }
+    }
+
+    private static async Task<int> RunStreamingSessionAsync(CliOptions options)
+    {
+        var connection = await ConnectAsync(options);
+        if (connection is null)
+        {
+            return 1;
+        }
+
+        var device = connection.Device;
+        var connectionDescription = connection.Description;
 
         using var _ = device;
         using var outputWriter = CreateOutputWriter(options);
@@ -222,7 +270,7 @@ internal class Program
 
             if (options.ShowStatusMessages && ProtobufProtocolHandler.DetectMessageType(message) == ProtobufMessageType.Status)
             {
-                WriteStatusSummary(outputWriter, message);
+                WriteStatusSummary(message);
                 return;
             }
 
@@ -276,6 +324,15 @@ internal class Program
         try
         {
             Console.WriteLine($"Connected to {connectionDescription}");
+
+            if (options.ShowStatusMessages)
+            {
+                // The device's status message is requested and consumed during connect, before this
+                // method gets a chance to subscribe, and the device does not re-send one while
+                // streaming. Print the summary from the metadata that connect already parsed
+                // instead of waiting for a message that will never arrive.
+                WriteStatusSummary(device.Metadata);
+            }
 
             if (!string.IsNullOrWhiteSpace(options.ChannelMask))
             {
@@ -354,35 +411,14 @@ internal class Program
             return 1;
         }
 
-        var connectionOptions = new DeviceConnectionOptions
+        var connection = await ConnectAsync(options);
+        if (connection is null)
         {
-            ConnectionRetry = new ConnectionRetryOptions
-            {
-                Enabled = options.ConnectAttempts > 1,
-                MaxAttempts = Math.Max(1, options.ConnectAttempts),
-                ConnectionTimeout = TimeSpan.FromSeconds(options.ConnectTimeoutSeconds)
-            }
-        };
-
-        DaqifiDevice device;
-        string connectionDescription;
-
-        if (!string.IsNullOrWhiteSpace(options.SerialPort))
-        {
-            device = await DaqifiDeviceFactory.ConnectSerialAsync(
-                options.SerialPort,
-                options.BaudRate,
-                connectionOptions);
-            connectionDescription = $"{options.SerialPort} @ {options.BaudRate} baud";
+            return 1;
         }
-        else
-        {
-            device = await DaqifiDeviceFactory.ConnectTcpAsync(
-                options.IpAddress!,
-                options.Port,
-                connectionOptions);
-            connectionDescription = $"{options.IpAddress}:{options.Port}";
-        }
+
+        var device = connection.Device;
+        var connectionDescription = connection.Description;
 
         using var _ = device;
         using var hidTransport = new HidLibraryTransport();
@@ -793,35 +829,31 @@ internal class Program
 
     private static async Task<int> RunSdCardOperationAsync(CliOptions options)
     {
-        var connectionOptions = new DeviceConnectionOptions
+        // Resolve (and reject) the download destination before connecting, so a bad path costs
+        // nothing and can never be discovered after a long transfer.
+        string? sdDownloadDestination = null;
+        if (!string.IsNullOrWhiteSpace(options.SdDownloadFileName))
         {
-            ConnectionRetry = new ConnectionRetryOptions
+            sdDownloadDestination = ResolveSdDownloadDestination(
+                options.SdDownloadFileName,
+                options.SdDownloadDestination,
+                out var destinationError);
+
+            if (sdDownloadDestination is null)
             {
-                Enabled = options.ConnectAttempts > 1,
-                MaxAttempts = Math.Max(1, options.ConnectAttempts),
-                ConnectionTimeout = TimeSpan.FromSeconds(options.ConnectTimeoutSeconds)
+                Console.Error.WriteLine(destinationError);
+                return 1;
             }
-        };
-
-        DaqifiDevice device;
-        string connectionDescription;
-
-        if (!string.IsNullOrWhiteSpace(options.SerialPort))
-        {
-            device = await DaqifiDeviceFactory.ConnectSerialAsync(
-                options.SerialPort,
-                options.BaudRate,
-                connectionOptions);
-            connectionDescription = $"{options.SerialPort} @ {options.BaudRate} baud";
         }
-        else
+
+        var connection = await ConnectAsync(options);
+        if (connection is null)
         {
-            device = await DaqifiDeviceFactory.ConnectTcpAsync(
-                options.IpAddress!,
-                options.Port,
-                connectionOptions);
-            connectionDescription = $"{options.IpAddress}:{options.Port}";
+            return 1;
         }
+
+        var device = connection.Device;
+        var connectionDescription = connection.Description;
 
         using var _ = device;
 
@@ -969,29 +1001,60 @@ internal class Program
                     Console.Write($"\r  Received {p.BytesReceived:N0} bytes...");
                 });
 
-                var result = await streamingDevice.DownloadSdCardFileAsync(
-                    options.SdDownloadFileName, progress);
+                // The destination-stream overload is used instead of the convenience overload so
+                // the file lands where the user can find it. The convenience overload writes to
+                // Path.GetTempPath()/daqifi_<guid>.bin, which is subject to OS temp cleanup and
+                // bears no relation to the source name.
+                var destinationPath = sdDownloadDestination!;
+                SdCardDownloadResult result;
+
+                // Tracks whether this process actually created the file, so the cleanup below can
+                // never delete a file someone else created between the check above and the open.
+                var createdDestination = false;
+                try
+                {
+                    // CreateNew rather than Create: the destination was checked above, and this
+                    // closes the race so a concurrent writer's file is never truncated.
+                    await using var destinationStream = new FileStream(
+                        destinationPath,
+                        FileMode.CreateNew,
+                        FileAccess.Write,
+                        FileShare.None,
+                        bufferSize: 65536,
+                        useAsync: true);
+                    createdDestination = true;
+
+                    result = await streamingDevice.DownloadSdCardFileAsync(
+                        options.SdDownloadFileName, destinationStream, progress);
+                }
+                catch
+                {
+                    // A failed transfer leaves a partial (often empty) file behind, which is easy
+                    // to mistake for a good download. Remove it and let the error propagate.
+                    if (createdDestination)
+                    {
+                        try { File.Delete(destinationPath); } catch { /* best effort */ }
+                    }
+
+                    throw;
+                }
 
                 Console.WriteLine();
                 Console.WriteLine($"Download complete: {result.FileSize:N0} bytes in {result.Duration.TotalSeconds:F1}s");
+                Console.WriteLine($"Saved to: {destinationPath}");
 
-                if (result.FilePath != null)
+                // Parse the downloaded file (any supported format)
+                var downloadExt = Path.GetExtension(destinationPath).ToLowerInvariant();
+                if (downloadExt is ".bin" or ".csv" or ".json")
                 {
-                    Console.WriteLine($"Saved to: {result.FilePath}");
+                    Console.WriteLine();
+                    Console.WriteLine("--- Parsing downloaded file ---");
+                    options.SdParsePath = destinationPath;
 
-                    // Parse the downloaded file (any supported format)
-                    var downloadExt = Path.GetExtension(result.FilePath).ToLowerInvariant();
-                    if (downloadExt is ".bin" or ".csv" or ".json")
-                    {
-                        Console.WriteLine();
-                        Console.WriteLine("--- Parsing downloaded file ---");
-                        options.SdParsePath = result.FilePath;
-
-                        // Pass the connected device's config so the parser can
-                        // scale raw ADC values using the device's calibration.
-                        var deviceConfig = SdCardDeviceConfiguration.FromDevice((DaqifiDevice)device);
-                        return await RunSdCardParseAsync(options, deviceConfig);
-                    }
+                    // Pass the connected device's config so the parser can
+                    // scale raw ADC values using the device's calibration.
+                    var deviceConfig = SdCardDeviceConfiguration.FromDevice((DaqifiDevice)device);
+                    return await RunSdCardParseAsync(options, deviceConfig);
                 }
             }
             else if (options.SdFormat)
@@ -1027,6 +1090,84 @@ internal class Program
                 Console.Error.WriteLine($"Disconnect error: {FormatException(ex)}");
             }
         }
+    }
+
+    /// <summary>
+    /// Works out where <c>--sd-download</c> should write, defaulting to the source file name in the
+    /// current directory and honouring <c>--sd-download-to</c> when given.
+    /// </summary>
+    /// <param name="sourceFileName">The file name on the device's SD card.</param>
+    /// <param name="requestedDestination">The <c>--sd-download-to</c> value, if any.</param>
+    /// <param name="error">Set to the message to print when the destination is unusable.</param>
+    /// <returns>The absolute destination path, or <c>null</c> when it is unusable.</returns>
+    private static string? ResolveSdDownloadDestination(
+        string sourceFileName,
+        string? requestedDestination,
+        out string? error)
+    {
+        error = null;
+
+        // The file name is echoed back from the device's own listing, so treat it as untrusted:
+        // strip any directory component before using it, or a name like "../../evil.bin" would
+        // write outside the directory the user chose.
+        var safeName = Path.GetFileName(sourceFileName.Trim());
+        if (string.IsNullOrWhiteSpace(safeName) || safeName is "." or "..")
+        {
+            error = $"Cannot derive a destination file name from '{sourceFileName}'. Use --sd-download-to <path>.";
+            return null;
+        }
+
+        string candidate;
+        if (string.IsNullOrWhiteSpace(requestedDestination))
+        {
+            candidate = safeName;
+        }
+        else if (Directory.Exists(requestedDestination) || EndsWithDirectorySeparator(requestedDestination))
+        {
+            candidate = Path.Combine(requestedDestination, safeName);
+        }
+        else
+        {
+            candidate = requestedDestination;
+        }
+
+        string destinationPath;
+        try
+        {
+            destinationPath = Path.GetFullPath(candidate);
+        }
+        catch (Exception ex)
+        {
+            error = $"Invalid destination path '{candidate}': {FormatException(ex)}";
+            return null;
+        }
+
+        if (Directory.Exists(destinationPath))
+        {
+            error = $"Destination is a directory: {destinationPath}";
+            return null;
+        }
+
+        if (File.Exists(destinationPath))
+        {
+            error = $"Destination already exists: {destinationPath}. " +
+                    "Use --sd-download-to <path> to write somewhere else, or remove the existing file.";
+            return null;
+        }
+
+        var directory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            error = $"Destination directory does not exist: {directory}";
+            return null;
+        }
+
+        return destinationPath;
+    }
+
+    private static bool EndsWithDirectorySeparator(string path)
+    {
+        return path.EndsWith(Path.DirectorySeparatorChar) || path.EndsWith(Path.AltDirectorySeparatorChar);
     }
 
     private static async Task<int> RunSdCardParseAsync(
@@ -1164,12 +1305,12 @@ internal class Program
         await using (var fileStream = new FileStream(outputPath, FileMode.Create, FileAccess.Write, FileShare.Read))
         await using (var writer = new StreamWriter(fileStream))
         {
-            var countingSource = new CountingSampleSource(sampleSource, count =>
+            var countingSource = new RowCountingSampleSource(sampleSource, rows =>
             {
-                rowsWritten = count;
+                rowsWritten = rows;
                 if (stopwatch.Elapsed - lastReport > TimeSpan.FromMilliseconds(250))
                 {
-                    Console.Write($"\r  {count} rows written ({count / Math.Max(1, stopwatch.Elapsed.TotalSeconds):N0} rows/s)");
+                    Console.Write($"\r  {rows} rows written ({rows / Math.Max(1, stopwatch.Elapsed.TotalSeconds):N0} rows/s)");
                     lastReport = stopwatch.Elapsed;
                 }
             });
@@ -1214,35 +1355,14 @@ internal class Program
     /// </summary>
     private static async Task<int> RunCaptureAndParseAsync(CliOptions options)
     {
-        var connectionOptions = new DeviceConnectionOptions
+        var connection = await ConnectAsync(options);
+        if (connection is null)
         {
-            ConnectionRetry = new ConnectionRetryOptions
-            {
-                Enabled = options.ConnectAttempts > 1,
-                MaxAttempts = Math.Max(1, options.ConnectAttempts),
-                ConnectionTimeout = TimeSpan.FromSeconds(options.ConnectTimeoutSeconds)
-            }
-        };
-
-        DaqifiDevice device;
-        string connectionDescription;
-
-        if (!string.IsNullOrWhiteSpace(options.SerialPort))
-        {
-            device = await DaqifiDeviceFactory.ConnectSerialAsync(
-                options.SerialPort,
-                options.BaudRate,
-                connectionOptions);
-            connectionDescription = $"{options.SerialPort} @ {options.BaudRate} baud";
+            return 1;
         }
-        else
-        {
-            device = await DaqifiDeviceFactory.ConnectTcpAsync(
-                options.IpAddress!,
-                options.Port,
-                connectionOptions);
-            connectionDescription = $"{options.IpAddress}:{options.Port}";
-        }
+
+        var device = connection.Device;
+        var connectionDescription = connection.Description;
 
         using var _ = device;
         var capturePath = options.CaptureAndParsePath!;
@@ -1326,35 +1446,14 @@ internal class Program
 
     private static async Task<int> RunLanChipInfoAsync(CliOptions options)
     {
-        var connectionOptions = new DeviceConnectionOptions
+        var connection = await ConnectAsync(options);
+        if (connection is null)
         {
-            ConnectionRetry = new ConnectionRetryOptions
-            {
-                Enabled = options.ConnectAttempts > 1,
-                MaxAttempts = Math.Max(1, options.ConnectAttempts),
-                ConnectionTimeout = TimeSpan.FromSeconds(options.ConnectTimeoutSeconds)
-            }
-        };
-
-        DaqifiDevice device;
-        string connectionDescription;
-
-        if (!string.IsNullOrWhiteSpace(options.SerialPort))
-        {
-            device = await DaqifiDeviceFactory.ConnectSerialAsync(
-                options.SerialPort,
-                options.BaudRate,
-                connectionOptions);
-            connectionDescription = $"{options.SerialPort} @ {options.BaudRate} baud";
+            return 1;
         }
-        else
-        {
-            device = await DaqifiDeviceFactory.ConnectTcpAsync(
-                options.IpAddress!,
-                options.Port,
-                connectionOptions);
-            connectionDescription = $"{options.IpAddress}:{options.Port}";
-        }
+
+        var device = connection.Device;
+        var connectionDescription = connection.Description;
 
         using var _ = device;
 
@@ -1437,11 +1536,39 @@ internal class Program
         }
     }
 
-    private static void WriteStatusSummary(TextWriter writer, DaqifiOutMessage message)
+    /// <summary>
+    /// Prints the device's reported channel counts, firmware revision and serial number from the
+    /// metadata that connect/initialization already parsed.
+    /// </summary>
+    private static void WriteStatusSummary(DeviceMetadata metadata)
     {
-        writer.WriteLine(
-            $"Status: analogIn={message.AnalogInPortNum} digital={message.DigitalPortNum} " +
-            $"fw={message.DeviceFwRev ?? "unknown"} sn={message.DeviceSn}");
+        WriteStatusSummary(
+            metadata.Capabilities.AnalogInputChannels,
+            metadata.Capabilities.DigitalChannels,
+            metadata.FirmwareVersion,
+            metadata.SerialNumber);
+    }
+
+    /// <summary>
+    /// Prints the same summary for a status message that arrives while a handler is subscribed.
+    /// </summary>
+    private static void WriteStatusSummary(DaqifiOutMessage message)
+    {
+        WriteStatusSummary(
+            (int)message.AnalogInPortNum,
+            (int)message.DigitalPortNum,
+            message.DeviceFwRev,
+            message.DeviceSn == 0 ? null : message.DeviceSn.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static void WriteStatusSummary(int analogInPorts, int digitalPorts, string? firmware, string? serialNumber)
+    {
+        // Written to the console rather than the sample output writer: this is diagnostic output,
+        // and mixing it into a --output CSV/JSONL file would corrupt the data.
+        Console.WriteLine(
+            $"Status: analogIn={analogInPorts} digital={digitalPorts} " +
+            $"fw={(string.IsNullOrWhiteSpace(firmware) ? "unknown" : firmware)} " +
+            $"sn={(string.IsNullOrWhiteSpace(serialNumber) ? "unknown" : serialNumber)}");
     }
 
     private static string ToTextLine(DaqifiOutMessage analogMsg, DaqifiOutMessage? digitalMsg)
@@ -1580,7 +1707,7 @@ internal class Program
         Console.WriteLine("Output Options:");
         Console.WriteLine("  --format <text|csv|jsonl> Output format for stream samples (default: text).");
         Console.WriteLine("  --output <path>          Write samples to file instead of stdout.");
-        Console.WriteLine("  --show-status            Print protobuf status messages when received.");
+        Console.WriteLine("  --show-status            Print the device status summary after connecting.");
         Console.WriteLine();
         Console.WriteLine("SD Card Options:");
         Console.WriteLine("  --sd-list                List files on the SD card (USB/serial only).");
@@ -1589,7 +1716,9 @@ internal class Program
         Console.WriteLine("  --sd-log-format <fmt>    Log format: protobuf (default), json, csv.");
         Console.WriteLine("  --sd-log-stop            Stop SD card logging.");
         Console.WriteLine("  --sd-delete <filename>   Delete a file from the SD card.");
-        Console.WriteLine("  --sd-download <filename> Download a file from the SD card (USB/serial only).");
+        Console.WriteLine("  --sd-download <filename> Download a file from the SD card, saved as ./<filename>.");
+        Console.WriteLine("  --sd-download-to <path>  Destination for --sd-download: a file path, or a directory to");
+        Console.WriteLine("                           save under the source file name. Never overwrites.");
         Console.WriteLine("  --sd-format              Format the SD card (erases all data).");
         Console.WriteLine("  --sd-parse <path>        Parse a .bin log file from the SD card.");
         Console.WriteLine("  --sd-export-csv <path>   With --sd-parse, write samples as CSV to <path> using Daqifi.Core's CsvExporter.");
@@ -1663,6 +1792,7 @@ internal class Program
         public SdCardLogFormat SdLogFormat { get; private set; } = SdCardLogFormat.Protobuf;
         public string? SdDeleteFileName { get; private set; }
         public string? SdDownloadFileName { get; private set; }
+        public string? SdDownloadDestination { get; private set; }
         public bool SdFormat { get; private set; }
         public bool SdStorage { get; private set; }
         public string? SdParsePath { get; set; }
@@ -1763,6 +1893,9 @@ internal class Program
                         break;
                     case "--sd-download":
                         options.SdDownloadFileName = GetValue(args, ref i, arg, options.Errors);
+                        break;
+                    case "--sd-download-to":
+                        options.SdDownloadDestination = GetValue(args, ref i, arg, options.Errors);
                         break;
                     case "--sd-format":
                         options.SdFormat = true;
@@ -1891,6 +2024,12 @@ internal class Program
                 string.IsNullOrWhiteSpace(options.SdParsePath))
             {
                 options.Errors.Add("--sd-export-csv requires --sd-parse <path>.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.SdDownloadDestination) &&
+                string.IsNullOrWhiteSpace(options.SdDownloadFileName))
+            {
+                options.Errors.Add("--sd-download-to requires --sd-download <filename>.");
             }
 
             return options;

--- a/Program.cs
+++ b/Program.cs
@@ -1174,8 +1174,14 @@ internal class Program
     /// <summary>
     /// Whether <paramref name="fileName"/> names a log format the parser understands.
     /// </summary>
+    /// <remarks>
+    /// The extensions are listed here rather than read from Core (<c>TryDetectFormat</c> /
+    /// <c>SupportedExtensions</c>) because this project also builds against the pinned
+    /// <c>Daqifi.Core</c> package release, which predates both — the same reason
+    /// <see cref="GetLogFormatLabel(string)"/> lists them too.
+    /// </remarks>
     private static bool IsParseableLogFile(string fileName)
-        => SdCardFileParserFactory.TryDetectFormat(fileName, out _);
+        => Path.GetExtension(fileName).ToLowerInvariant() is ".bin" or ".csv" or ".json";
 
     private static bool EndsWithDirectorySeparator(string path)
     {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ dotnet run -- \
 - `--sd-log-start` start SD card logging (USB/Serial only)
 - `--sd-log-stop` stop SD card logging (USB/Serial only)
 - `--sd-download <filename>` download a file from the SD card and parse it, saved as `./<filename>`
-- `--sd-download-to <path>` destination for `--sd-download`: a file path, or a directory to save under the source file name (never overwrites an existing file)
+- `--sd-download-to <path>` destination for `--sd-download`: a file path, or a directory to save under the source file name
+- `--overwrite` allow `--sd-download` to replace an existing destination file (refused by default)
 - `--sd-delete <filename>` delete a file from the SD card (USB/Serial only)
 - `--sd-format` format the SD card (USB/Serial only)
 - `--fw-download-latest <dir>` download latest PIC32 firmware HEX into `<dir>`

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ dotnet run -- \
 - `--connect-timeout <seconds>` TCP connect timeout (default 5)
 - `--connect-attempts <n>` total connect attempts (default 1)
 - `--keep-connected` keep connection open after streaming stops
-- `--show-status` print protobuf status messages
+- `--show-status` print the device status summary (channel counts, firmware, serial) after connecting
 - `--discover-timeout <seconds>` discovery timeout (default 5)
 - `--sd-list` list files on the SD card (USB/Serial only)
 - `--sd-storage` show SD card free/used/total space (USB/Serial only)
 - `--sd-log-start` start SD card logging (USB/Serial only)
 - `--sd-log-stop` stop SD card logging (USB/Serial only)
-- `--sd-download <filename>` download a file from the SD card and parse it (USB/Serial only)
+- `--sd-download <filename>` download a file from the SD card and parse it, saved as `./<filename>`
+- `--sd-download-to <path>` destination for `--sd-download`: a file path, or a directory to save under the source file name (never overwrites an existing file)
 - `--sd-delete <filename>` delete a file from the SD card (USB/Serial only)
 - `--sd-format` format the SD card (USB/Serial only)
 - `--fw-download-latest <dir>` download latest PIC32 firmware HEX into `<dir>`
@@ -100,10 +101,17 @@ Stop logging:
 dotnet run -- --serial /dev/cu.usbmodem2101 --sd-log-stop
 ```
 
-Download and parse a file:
+Download and parse a file (saved as `./log_20260206_101851.bin`):
 
 ```bash
 dotnet run -- --serial /dev/cu.usbmodem2101 --sd-download log_20260206_101851.bin
+```
+
+Download to a specific destination:
+
+```bash
+dotnet run -- --serial /dev/cu.usbmodem2101 --sd-download log_20260206_101851.bin \
+  --sd-download-to ~/captures/
 ```
 
 Delete a file:

--- a/SdCardSampleSource.cs
+++ b/SdCardSampleSource.cs
@@ -73,18 +73,25 @@ internal sealed class SdCardSampleSource : ISampleSource
 }
 
 /// <summary>
-/// Wraps any <see cref="ISampleSource"/> and invokes a callback after each sample, used by the
-/// CLI to drive a throughput-aware progress display without changing the underlying source.
+/// Wraps any <see cref="ISampleSource"/> and reports a running count of the CSV rows
+/// <see cref="CsvExporter"/> will write, used by the CLI to drive a throughput-aware progress
+/// display without changing the underlying source.
 /// </summary>
-internal sealed class CountingSampleSource : ISampleSource
+/// <remarks>
+/// The exporter collapses every consecutive <see cref="SampleRow"/> that shares a timestamp into a
+/// single CSV line, so a row is a timestamp, not a sample. Counting the samples themselves — one
+/// per channel per log entry — over-reports by the channel count, which is what made a 95-sample
+/// two-channel export claim 190 rows for a 96-line file.
+/// </remarks>
+internal sealed class RowCountingSampleSource : ISampleSource
 {
     private readonly ISampleSource _inner;
-    private readonly Action<long> _onSample;
+    private readonly Action<long> _onRow;
 
-    public CountingSampleSource(ISampleSource inner, Action<long> onSample)
+    public RowCountingSampleSource(ISampleSource inner, Action<long> onRow)
     {
         _inner = inner;
-        _onSample = onSample;
+        _onRow = onRow;
     }
 
     public IReadOnlyList<ChannelDescriptor> GetChannels() => _inner.GetChannels();
@@ -95,11 +102,21 @@ internal sealed class CountingSampleSource : ISampleSource
     public async IAsyncEnumerable<SampleRow> StreamSamples(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        long count = 0;
+        long rows = 0;
+        long? currentTicks = null;
+
         await foreach (var sample in _inner.StreamSamples(cancellationToken))
         {
-            count++;
-            _onSample(count);
+            // Mirrors the exporter's own grouping rule (flush when the timestamp changes), so the
+            // count matches the file line for line — including when consecutive entries repeat a
+            // timestamp and the exporter merges them into one row.
+            if (currentTicks != sample.TimestampTicks)
+            {
+                currentTicks = sample.TimestampTicks;
+                rows++;
+                _onRow(rows);
+            }
+
             yield return sample;
         }
     }


### PR DESCRIPTION
## Why

Four small things in the example CLI were misleading people. A failed connect — the most common thing that goes wrong — printed a .NET stack trace and aborted with exit code 134 instead of saying what happened. A CSV export claimed to have written twice as many rows as the file contained. `--sd-download` saved your file to a GUID-named path in the system temp directory. And `--show-status` printed nothing at all.

## What

Connect failures now print one line and exit 1, like every other failure in the tool. `--sd-export-csv` reports the number of rows actually in the file. `--sd-download` saves to `./<filename>` and takes a new `--sd-download-to` to pick somewhere else. `--show-status` prints the device summary right after connecting.

## How

The five copies of the connect block became one `ConnectAsync` helper that catches broadly — the transport surfaces connect failures as a long and changing list of exception types, so naming them would leave the crash in place for whichever one we missed — with a last-resort handler in `Main` as a backstop. The row counter now counts timestamp changes rather than `SampleRow` emissions, mirroring how `CsvExporter` groups rows, so the reported figure matches the file line for line. The download switches to Core's destination-stream overload; the destination is resolved and rejected *before* connecting, the source name is stripped to a bare filename so a device-supplied `../../x.bin` cannot escape the target directory, existing files are never overwritten, and a failed transfer deletes the partial file rather than leaving an empty one that looks like a good download. The status summary is read from `device.Metadata`, which connect has already populated, instead of waiting for a message that was consumed before the handler was attached.

A note on `--sd-download-to` rather than reusing `--output`: after downloading, the CLI parses the file and its text dump goes to `--output` via `CreateOutputWriter`, which opens the path with `FileMode.Create`. Reusing `--output` would have truncated the file that had just been downloaded.

## Bench test

Bench Nq1, FW 3.7.2, built against Core `main` @ 359bf74.

**#39 — connect failures (USB and TCP)**
```
$ dotnet Daqifi.Core.Cli.dll --serial /dev/cu.doesnotexist --duration 2
Error: Could not connect to /dev/cu.doesnotexist @ 9600 baud: UnauthorizedAccessException: ... | Inner IOException: No such file or directory
$ echo $?
1

$ dotnet Daqifi.Core.Cli.dll --ip 192.168.1.244 --connect-timeout 2 --duration 2
Error: Could not connect to 192.168.1.244:9760: TimeoutException: TCP connect to 192.168.1.244:9760 timed out after 2s. | Inner TaskCanceledException: A task was canceled.
$ echo $?
1
```
Previously both printed a stack trace and exited 134.

**#42 — `--show-status` over USB**
```
Connected to /dev/cu.usbmodem1101 @ 9600 baud
Status: analogIn=16 digital=16 fw=3.7.2 sn=9090539562006014104
Streaming at 10 Hz...
```
Previously this line never appeared.

**#41 — `--sd-download`**, real 6 s SD capture downloaded off the card:
```
bench/log_20260802_104022.bin              1805 bytes   # default: ./<source filename>
bench/captures/log_20260802_104022.bin     1805 bytes   # via --sd-download-to <dir>

$ dotnet Daqifi.Core.Cli.dll --serial <port> --sd-download log_20260802_104022.bin
Destination already exists: .../log_20260802_104022.bin. Use --sd-download-to <path> to write somewhere else, or remove the existing file.
$ echo $?
1
```
A transfer that stalled mid-run (a known low-heap state on this unit) left the directory empty rather than a 0-byte file, and exited 1 with a single line.

**#40 — CSV row count**, same real capture, before and after:
```
before (origin/main):  Wrote 186 rows (3,298 bytes)     wc -l = 94
after  (this branch):  Wrote  93 rows (3,298 bytes)     wc -l = 94
```
94 lines = 93 data rows + header, so the new figure is exact; the two CSV files are byte-identical, only the reported number changed.

**TCP `--show-status` not covered.** After the SD-over-USB work the device answered ping but timed out during channel-configuration init over TCP, so the WiFi session only exercised the connect-failure path (cleanly, exit 1). Validating `--show-status` over TCP needs a power cycle. The code path is transport-independent — it reads `device.Metadata`, which the factory populates identically for both transports.

The truncation warning visible in the export (`sample has 2 analog values but configured channel count is 1`) is the known malformed-first-frame / channel-count-inference bug tracked in daqifi-core#425 and #34, not something introduced here.

Closes #39
Closes #40
Closes #41
Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)