### PR TITLE
chore: add Dependabot config and minimal CI build workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore


### PR DESCRIPTION
Adds `.github/dependabot.yml` and a minimal `.github/workflows/ci.yml`.

## Dependabot

- **Ecosystems:** `nuget` (the single `Daqifi.Core` PackageReference in `Daqifi.Core.Cli.csproj`) and `github-actions` (for the workflow this PR adds).
- **Schedule:** weekly, both ecosystems.
- **Grouping:** minor + patch bumps collapse into one `minor-and-patch` PR per ecosystem. Major bumps still open individually so they get reviewed on their own.

## CI

Runs on `pull_request` only. `dotnet restore` + `dotnet build -c Release` on `ubuntu-latest`, pinned to the `9.0.x` SDK to match the project's `net9.0` target. There's no test project, so this is build-only for now — it exists mainly so Dependabot's grouped bumps have something to go green against instead of merging with zero signal.

Verified before opening: `Daqifi.Core` resolves from public nuget.org (no feed credentials needed in CI), a clean `dotnet build -c Release` passes with 0 warnings / 0 errors, both YAML files parse, and the `actions/checkout@v7` / `actions/setup-dotnet@v6` tags resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)